### PR TITLE
Mediathek von Game Two und Twitch

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.25.0" />
         <import addon="plugin.video.youtube" version="5.2.1" />
+        <import addon="plugin.video.twitch" version="2.2.0" />
         <import addon="script.module.routing" version="0.2.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">

--- a/resources/data/config.py
+++ b/resources/data/config.py
@@ -4,4 +4,5 @@ GAME_TWO_CHANNEL_ID = 'UCFBapHA35loZ3KZwT_z3BsQ'
 
 GUIDE_URL = 'http://api.rbtv.rodney.io/api/1.0/schedule/schedule_linear.json'
 
-TWITCH_CHANNEL_ID = '47627824'
+TWITCH_CHANNEL_ID = 'rocketbeanstv'
+TWITCH_CLIENT_ID = 'NjdlYnBmaHlvaWNhYjVrcjB5N3B6b2NzZm9oczd0eQ=='

--- a/resources/data/config.py
+++ b/resources/data/config.py
@@ -1,3 +1,7 @@
 CHANNEL_ID = 'ROCKETBEANSTV'
 LETS_PLAY_CHANNEL_ID = 'UCtSP1OA6jO4quIGLae7Fb4g'
+GAME_TWO_CHANNEL_ID = 'UCFBapHA35loZ3KZwT_z3BsQ'
+
 GUIDE_URL = 'http://api.rbtv.rodney.io/api/1.0/schedule/schedule_linear.json'
+
+TWITCH_CHANNEL_ID = '47627824'

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -11,6 +11,7 @@ from resources.lib.guide import show_guide
 from resources.lib.youtube import get_live_video_id_from_channel_id
 from xbmcgui import ListItem
 from xbmcplugin import addDirectoryItem, endOfDirectory, setContent
+from xbmcaddon import Addon
 
 plugin = routing.Plugin()
 setContent(plugin.handle, 'videos')
@@ -19,7 +20,10 @@ setContent(plugin.handle, 'videos')
 @plugin.route('/')
 def index():
     video_id, title = get_live_video_id_from_channel_id(config.CHANNEL_ID)
-    url = "plugin://plugin.video.youtube/play/?video_id=%s" % video_id
+    if Addon().getSetting("stream") == "Twitch":
+        url = "plugin://plugin.video.twitch/?mode=play&channel_id=%s" % config.TWITCH_CHANNEL_ID
+    else:
+        url = "plugin://plugin.video.youtube/play/?video_id=%s" % video_id
     li = ListItem(label="Live | " + title,
                   thumbnailImage="https://i.ytimg.com/vi/%s/maxresdefault_live.jpg#%s" % (video_id, time.localtime()))
     li.setProperty('isPlayable', 'true')
@@ -32,6 +36,20 @@ def index():
     url = "plugin://plugin.video.youtube/channel/%s/" % config.LETS_PLAY_CHANNEL_ID
     addDirectoryItem(
         plugin.handle, url, ListItem('Let\'s-Play-Mediathek'), True)
+
+    addDirectoryItem(
+        plugin.handle,
+        "plugin://plugin.video.youtube/channel/%s/" % config.GAME_TWO_CHANNEL_ID,
+        ListItem("Game-Two-Mediathek"),
+        True 
+    )
+
+    addDirectoryItem(
+        plugin.handle,
+        "plugin://plugin.video.twitch/?mode=channel_video_list&broadcast_type=upload&channel_id=%s" %(config.TWITCH_CHANNEL_ID),
+        ListItem("Twitch-Mediathek"),
+        True
+    )
 
     addDirectoryItem(
         plugin.handle, plugin.url_for(guide), ListItem('Sendeplan'), True)

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -13,19 +13,23 @@ from xbmcgui import ListItem
 from xbmcplugin import addDirectoryItem, endOfDirectory, setContent
 from xbmcaddon import Addon
 
+from resources.lib.twitch import TwitchStream
+
 plugin = routing.Plugin()
 setContent(plugin.handle, 'videos')
 
 
 @plugin.route('/')
 def index():
-    video_id, title = get_live_video_id_from_channel_id(config.CHANNEL_ID)
     if Addon().getSetting("stream") == "Twitch":
-        url = "plugin://plugin.video.twitch/?mode=play&channel_id=%s" % config.TWITCH_CHANNEL_ID
+        t = TwitchStream(config.TWITCH_CHANNEL_ID)
+        url, title, thumbnail = t.url, t.title, t.thumbnail
     else:
+        video_id, title = get_live_video_id_from_channel_id(config.CHANNEL_ID)
         url = "plugin://plugin.video.youtube/play/?video_id=%s" % video_id
+        thumbnail = "https://i.ytimg.com/vi/%s/maxresdefault_live.jpg#%s" % (video_id, time.localtime())
     li = ListItem(label="Live | " + title,
-                  thumbnailImage="https://i.ytimg.com/vi/%s/maxresdefault_live.jpg#%s" % (video_id, time.localtime()))
+                  thumbnailImage=thumbnail)
     li.setProperty('isPlayable', 'true')
     li.setInfo(type=u'video', infoLabels={'title': title, 'plot': 'The live stream.'})
     addDirectoryItem(plugin.handle, url, li)
@@ -35,7 +39,7 @@ def index():
 
     url = "plugin://plugin.video.youtube/channel/%s/" % config.LETS_PLAY_CHANNEL_ID
     addDirectoryItem(
-        plugin.handle, url, ListItem('Let\'s-Play-Mediathek'), True)
+        plugin.handle, url, ListItem('Gaming Mediathek'), True)
 
     addDirectoryItem(
         plugin.handle,

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -47,7 +47,7 @@ def index():
     addDirectoryItem(
         plugin.handle,
         "plugin://plugin.video.twitch/?mode=channel_video_list&broadcast_type=upload&channel_id=%s" %(config.TWITCH_CHANNEL_ID),
-        ListItem("Twitch-Mediathek"),
+        ListItem("Mediathek auf Twitch"),
         True
     )
 

--- a/resources/lib/twitch.py
+++ b/resources/lib/twitch.py
@@ -1,0 +1,23 @@
+from urllib2 import Request, urlopen
+from json import loads
+from resources.data.config import TWITCH_CLIENT_ID
+
+from base64 import b64decode
+
+class TwitchStream:
+    def __init__(self, user_login):
+        payload = loads(
+            urlopen(
+                Request(
+                    "https://api.twitch.tv/helix/streams?user_login=%s" %user_login, 
+                    headers = { "Client-ID": b64decode(TWITCH_CLIENT_ID).decode("utf-8") }
+                )
+            ).read()
+        )["data"]
+        
+        if len(payload) > 0:
+            self.url = "plugin://plugin.video.twitch/?mode=play&channel_id=%s" %payload[0]["user_id"]
+            self.thumbnail = payload[0]["thumbnail_url"].format(height = "270", width = "480")
+            self.title = payload[0]["title"]
+        else:
+            raise Exception("Failed to fetch stream information from Twitch.")

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="stream" type="select" label="Plattform" values="YouTube|Twitch" default="YouTube" />
+    <setting id="stream" type="select" label="Livestream Quelle" values="YouTube|Twitch" default="YouTube" />
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <setting id="stream" type="select" label="Plattform" values="YouTube|Twitch" default="YouTube" />
+</settings>


### PR DESCRIPTION
Ich habe das Menü um die VoD-Angebote von Game Two und Rocket Beans auf Twitch.tv erweitert.
Außerdem gibt es die Option den Livestream auf Twitch anstatt auf YouTube zu starten. 